### PR TITLE
fix: release-please-action org name was renamed and updates accordingly

### DIFF
--- a/.github/workflows/on-merge.yml
+++ b/.github/workflows/on-merge.yml
@@ -2,7 +2,7 @@ name: On Merge
 
 on:
   push:
-    branches: [main]
+    branches: [master]
 
 permissions:
   contents: write

--- a/.github/workflows/on-pr.yml
+++ b/.github/workflows/on-pr.yml
@@ -2,7 +2,7 @@ name: On PR
 
 on:
   pull_request:
-    branches: [main]
+    branches: [master]
 
 permissions:
   pull-requests: read


### PR DESCRIPTION

# `google-github-actions` or was renamed to `googleapis`

Fixes google-github-actions was renamed to googleapis
