### PR TITLE
fix: rename configuration override and set default urls for realtime

### DIFF
--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -9,7 +9,7 @@ export interface ClientConfiguration {
 
 export interface ClientConfigurationOverrides {
   baseURL?: string;
-  realTimeClient?: string;
+  realTimeURL?: string;
 }
 
 export class Configuration {
@@ -26,7 +26,9 @@ export class Configuration {
         baseURL: overrides?.baseURL
           ? overrides.baseURL
           : "https://staging.tagshelf.com",
-        realTimeURL: overrides?.realTimeClient ? overrides.realTimeClient : "",
+        realTimeURL: overrides?.realTimeURL
+          ? overrides.realTimeURL
+          : "https://sockets.tagshelf.dev",
         version: 1,
         environment: "staging",
       };
@@ -36,7 +38,9 @@ export class Configuration {
       baseURL: overrides?.baseURL
         ? overrides.baseURL
         : "https://app.tagshelf.com",
-      realTimeURL: overrides?.realTimeClient ? overrides.realTimeClient : "",
+      realTimeURL: overrides?.realTimeURL
+        ? overrides.realTimeURL
+        : "https://sockets.tagshelf.io",
       version: 1,
       environment: "production",
     };

--- a/tests/socket/client.spec.ts
+++ b/tests/socket/client.spec.ts
@@ -10,7 +10,7 @@ import {
 jest.mock("socket.io-client");
 
 const config = Configuration.v1("staging", {
-  realTimeClient: "http://localhost:5000",
+  realTimeURL: "http://localhost:5000",
 });
 const apiKey = "AXXXXXXXX";
 


### PR DESCRIPTION
### Issue/Ticket: [AL-907](https://tagshelf.atlassian.net/browse/AL-907)

### 🛠 Changes

This pull request includes the following changes:

- **Renamed** the `realTimeClient` configuration override to `realTimeURL`.
- **Set default URLs** for `realTimeURL` in both staging and production environments.

### 📁 Modified Files

- `src/config/index.ts`


[AL-907]: https://tagshelf.atlassian.net/browse/AL-907?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ